### PR TITLE
Gravity Forms Google Calendar - gfCalendar Add

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A collection of third party add-ons for [Gravity Forms](http://www.gravityforms.
 - [Inline Edit by GravityView](https://gravityview.co/extensions/gravityview-inline-edit/) - Inline Edit is easiest and fastest way to edit Gravity Forms entries. GravityView not required.
 - [Gravity Forms Import Entries](https://gravityview.co/extensions/gravity-forms-entry-importer/) - The best way to import entries from a CSV into Gravity Forms.
 - [Gravity Forms Calendar](https://gravityview.co/extensions/calendar/) - Display your Gravity Forms entries in a flexible calendar.
+- [Gravity Forms Google Calendar - gfCalendar](http://gfcalendar.com/) - Create events in Google Calendar directly from your Gravity Forms without third-party services.
 - [Gravity Flow](https://gravityflow.io/) - Gravity Flow is a form-based workflow platform for WordPress based on Gravity Forms which allows users to implement complex workflow processes quickly and easily using simple drag and drop configuration.
 - [GF Chart](https://gfchart.com/) - GFChart is an extension to WordPress Gravity Forms. It empowers you to showcase a visual snapshot summary of form submissions - automatically.
 - [WP Raw HTML Form Importer for Gravity Forms](https://wordpress.org/plugins/better-raw-html-form-import-to-gravity-forms/) - Better Raw HTML Form Importer will give you a list of all inputs displayed in a table with editable label, name and value.


### PR DESCRIPTION
Create events in Google Calendar directly from your Gravity Forms without third-party services.